### PR TITLE
upgraded to OpenMQ version 4.5.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
 FROM java:8-jdk
 MAINTAINER Ladislav Gazo <gazo@seges.sk>
 
-ENV OPENMQ_VERSION 4.5
-ENV OPENMQ_ARCHIVE openmq4_5-binary-Linux_X86.zip
+ENV OPENMQ_VERSION 4.5.2
+ENV OPENMQ_ARCHIVE openmq4_5_2-binary-Linux_X86.zip
 
 ADD /config/config.properties /usr/local/openmq/MessageQueue4_5/var/mq/instances/imqbroker/props/config.properties
 
@@ -12,8 +12,8 @@ RUN useradd -d /home/openmq -u 1001 -s /bin/bash openmq && \
 #    mkdir -p /usr/local/openmq && \
 
 USER openmq
-RUN cd /usr/local/openmq && \
-    curl -v -o $OPENMQ_ARCHIVE http://download.java.net/mq/open-mq/$OPENMQ_VERSION/b29-fcs/$OPENMQ_ARCHIVE && \
+RUN cd /usr/local/openmq/MessageQueue4_5 && \
+    curl -v -o $OPENMQ_ARCHIVE http://download.oracle.com/mq/open-mq/$OPENMQ_VERSION/latest/$OPENMQ_ARCHIVE && \
     unzip $OPENMQ_ARCHIVE
 
 

--- a/docker-push.sh
+++ b/docker-push.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
-docker tag seges/openmq seges/openmq:4.5
+docker tag seges/openmq seges/openmq:4.5.2
 docker push seges/openmq


### PR DESCRIPTION
Besides the version number, a few other changes were needed:

- the root folder MessageQueue4_5 is not there anymore in the zip package, so the target path for the zip file has changed
- the download domain has changed in _download.oracle.com_
- used _latest_ as build number for download

I think it would be nice to have a separate version (tag) for 4.5.2 on both GitHub and Docker Hub.